### PR TITLE
Switched to wildcards in language key registration

### DIFF
--- a/src/client/js/x-translation.js
+++ b/src/client/js/x-translation.js
@@ -2157,11 +2157,10 @@ $translateProvider.translations('ja', {
 		$translateProvider.fallbackLanguage(['en']);
 		
 		$translateProvider.registerAvailableLanguageKeys(['en','cz','sk','ja'], {
-			'en_US': 'en',
-			'en_GB': 'en',
-			'cs': 'cz',
-			'sk': 'sk',
-			'ja': 'ja',
+			'en*': 'en',
+			'ja*': 'ja',
+			'cs*': 'cz',
+			'sk*': 'sk',
 			'*': 'en' // must be last
 		});
 		$translateProvider.determinePreferredLanguage();


### PR DESCRIPTION
- each regional variety is now correctly pointed to our lang. keys

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/membery/engine/21)

<!-- Reviewable:end -->
