### PR TITLE
[FIXED #101228816] textarea shows small font-size

### DIFF
--- a/src/client/scss/x/_fieldset.scss
+++ b/src/client/scss/x/_fieldset.scss
@@ -97,6 +97,7 @@ div.x-fieldset-row {
 			color: #555555;
 			min-height: 100px;
 			resize:both;
+			font-size: $base-font-size;
 	}
 
 	@media (max-width: $screen-sm) {


### PR DESCRIPTION
assigned a font attribute on the textarea.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/membery/engine/38)

<!-- Reviewable:end -->
