### PR TITLE
[FIXED #101703168] Added check for parent field to resolveGroupPermissions

### DIFF
--- a/src/server/securityController.js
+++ b/src/server/securityController.js
@@ -616,7 +616,7 @@ var SecurityController = function(mongoDriver, schemaRegistry, options) {
 		if (!gr) {
 			return;
 		}
-		if (gr.baseData.parent.oid) {
+		if (gr.baseData.parent && gr.baseData.parent.oid) {
 			this.resolveGroupPermissions(gr.baseData.parent.oid, allgroups, permissions);
 		}
 


### PR DESCRIPTION
- server was crashing when resolving permission group without parent

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/membery/engine/45)

<!-- Reviewable:end -->
