### PR TITLE
[FIXED #101229348] Fixed inline edit cancel in Safari

### DIFF
--- a/src/client/js/xpsui/directives/inlineedit.js
+++ b/src/client/js/xpsui/directives/inlineedit.js
@@ -129,7 +129,7 @@
 					enterViewMode();
 
 					scope.$apply(function() {
-						$parse(modelPath).assign(scope, oldValue); 
+						$parse(modelPath).assign(scope, oldValue);
 					});
 
 					formControl.releaseFocus(elm);
@@ -186,7 +186,7 @@
 					elm.attr('tabindex', '0');
 				
 					elm.on('focus', function(e) {
-						if (formControl.acquireFocus(elm)) {
+						if (formControl.acquireFocus(elm) && mode !== formGenerator.MODE.EDIT) {
 							enterEditMode();
 						}
 					});


### PR DESCRIPTION
In Safari, the focus handler was triggering the enterEditMode multiple times,
so the old value was being set to the current value and therefore the fields
weren't resetting properly. Added a condition to fix this.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/membery/engine/47)

<!-- Reviewable:end -->
