### PR TITLE
[FIXED #102158276] Fixed search by registrationID in objLink field

### DIFF
--- a/src/client/js/xpsui/directives/objectlink2-edit.js
+++ b/src/client/js/xpsui/directives/objectlink2-edit.js
@@ -116,11 +116,33 @@
 				selectbox.setInput(selfControl.getInput());
 				selectbox.setDropdown(dropdown);
 
-				// store
-				var dataset = dataFactory.createObjectDataset(schemaFragment);
-				selectbox.setDataset(dataset);
+				schemaUtil.getFieldsSchemaFragment(
+					schemaFragment.objectLink2.schema,
+					schemaFragment.objectLink2.fields,
+					function(fields) {
+						if (fields === null) {
+							return log.error('Could not load objLink field definitions');
+						}
 
-				log.groupEnd();
+						var firstField = fields[Object.keys(fields)[0]];
+						var options = {};
+
+						if(firstField.type === 'number') {
+							options.searchCondition = 'eq';
+							options.inputType = 'number';
+						}else if(firstField.type === 'string') {
+							options.searchCondition = 'starts';
+							options.inputType = 'string';
+						}
+
+						// store
+						var dataset = dataFactory.createObjectDataset(schemaFragment, options);
+						selectbox.setDataset(dataset);
+
+						log.groupEnd();
+					}
+				);
+
 			}
 		};
 	}]);

--- a/src/client/js/xpsui/services/selectdata-factory.js
+++ b/src/client/js/xpsui/services/selectdata-factory.js
@@ -187,7 +187,8 @@
 
 		ObjectLinkStore.DEFAULTS = {
 			searchCondition: 'starts',
-			orderBySort: 'asc'
+			orderBySort: 'asc',
+			inputType: 'string'
 		};
 
 		ObjectLinkStore.prototype.initFieldsSchema = function(callback){
@@ -271,7 +272,11 @@
 
 			//FIXME make sure that getSearchValue is always string and always non null
 			if (_searchVal && angular.isString(_searchVal) && _searchVal.length > 0) {
+				if(this.options.inputType === 'number') {
+					_searchVal = parseInt(_searchVal);
+				}
 				for (field in this.schema.fields) {
+
 					config.data.crits.push({
 						f: this.schema.fields[field],
 						v: _searchVal,
@@ -497,8 +502,8 @@
 
 				return new DataSet(store);
 			},
-			createObjectDataset: function(schemaFragment){
-				var store = new ObjectLinkStore();
+			createObjectDataset: function(schemaFragment, options){
+				var store = new ObjectLinkStore(options);
 
 				store.setSchema(schemaFragment.objectLink2)
 					.setForcedCriteria(schemaFragment.objectLink2ForcedCriteria)


### PR DESCRIPTION
- objLinks now use query operation based on type of first objLink field
- type is passed to selectdata-factory to correctly parse input value

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/membery/engine/60)

<!-- Reviewable:end -->
