### PR TITLE
[FIXED #104240680] Objectlink's clickable redirect does not prevent click propagation on Safari

### DIFF
--- a/src/client/js/xpsui/directives/inlineedit.js
+++ b/src/client/js/xpsui/directives/inlineedit.js
@@ -186,7 +186,7 @@
 					elm.attr('tabindex', '0');
 				
 					elm.on('focus', function(e) {
-						if (formControl.acquireFocus(elm) && mode !== formGenerator.MODE.EDIT) {
+						if (formControl.acquireFocus(elm) && e.srcElement.className != 'linkIcon') {
 							enterEditMode();
 						}
 					});

--- a/src/client/js/xpsui/directives/objectlink2-view.js
+++ b/src/client/js/xpsui/directives/objectlink2-view.js
@@ -36,7 +36,8 @@
 									);
 								var schemaUri = schemaFragment.objectLink2.schema;
 								schemaUri = schemaUri.substring(0, schemaUri.length - '/view'.length);
-								view.append('<a href="#/registry/view/' + xpsuiuriescape(schemaUri) + '/' + data.oid + '" ><i class="icon-external-link fa-1"></i></a>&nbsp;&nbsp;');
+								var linkPath = '#/registry/view/' + xpsuiuriescape(schemaUri) + '/' + data.oid;
++								view.append('<a href="' + linkPath + '"><div class="linkIcon" width="32px" height="64px"><i class="icon-external-link fa-1 blackiconcolor"></i>&nbsp;&nbsp;</div></a>');
 								objectlink2Factory.renderElement(
 									view, 
 									fields, 

--- a/src/client/scss/x/_font.scss
+++ b/src/client/scss/x/_font.scss
@@ -96,3 +96,6 @@ $icon-circle-o: $fa-var-circle-o !default;
 .icon-question-circle:before { content: $icon-question-circle }
 .icon-circle:before { content: $icon-circle }
 .icon-circle-o:before { content: $icon-circle-o }
+
+// Color class
+.blackiconcolor {color:black;}

--- a/src/client/scss/x/_objectlink2.scss
+++ b/src/client/scss/x/_objectlink2.scss
@@ -1,7 +1,7 @@
 .x-objectlink2-view{
 	@include inline-view();
 
-	> div{
+	div{
 		display: inline-block;
 	}
 


### PR DESCRIPTION
…lick propagation on Safari
- removed a focus trigger handler form enterEditMode to evade looping of the event
- added a div wrapper around the link arrow icon so that the inline edit can recognize the source
  element of the focus event; i.e. if the link arrow is focused it will not call enterEditMode method.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/membery/engine/87)

<!-- Reviewable:end -->
